### PR TITLE
Log if it failed to receive a token

### DIFF
--- a/lib/src/main/java/org/unifiedpush/android/embedded_fcm_distributor/EmbeddedDistributorReceiver.kt
+++ b/lib/src/main/java/org/unifiedpush/android/embedded_fcm_distributor/EmbeddedDistributorReceiver.kt
@@ -30,6 +30,12 @@ open class EmbeddedDistributorReceiver(private val handler: GetEndpointHandler) 
                     Log.d("UP-Registration", "FCMToken: $_fcmToken")
                     saveFCMToken(context, _fcmToken)
                     sendNewEndpoint(context, token, _fcmToken, instance)
+                }.addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        Log.d("UP-Registration", "Token received successfully")
+                    } else {
+                        Log.e("UP-Registration", "FCMToken registration failed: ${task.exception?.localizedMessage}")
+                    }
                 }
             }
             ACTION_UNREGISTER -> {


### PR DESCRIPTION
Add a completion listener, similar how Element Android has it, so we get similar error messages at least in the log. Next step could be exposing this to the application, so the application can react to this.